### PR TITLE
build: disabling build checks and enabling in ci

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Since the ".env" file is gitignored, you can use the ".env.example" file to
+# build a new ".env" file when you clone the repo. Keep this file up-to-date
+# when you add new variables to `.env`.
+
+# This file will be committed to version control, so make sure not to have any
+# secrets in it. If you are cloning this repo, create a copy of this file named
+# ".env" and populate it with your secrets.
+
+# When adding additional environment variables, the schema in "/src/env.js"
+# should be updated accordingly.
+
+# Drizzle
+POSTGRES_URL="postgresql://postgres:password@localhost:5432/t3gallery"
+
+# Example:
+# SERVERVAR="foo"
+# NEXT_PUBLIC_CLIENTVAR="bar"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,23 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Dependencies
+        run: npm install -g pnpm && pnpm install
+
+      - name: Copy .env.example files
+        shell: bash
+        run: find . -type f -name ".env.example" -exec sh -c 'cp "$1" "${1%.*}"' _ {} \;
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Lint
+        run: pnpm lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Dependencies
         run: npm install -g pnpm && pnpm install

--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,14 @@
 import "./src/env.js";
 
 /** @type {import("next").NextConfig} */
-const config = {};
+const config = {
+  /**Disabling checks during build because they are checked in CI in github actions */
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+  typescript: {
+    ignoreBuildErrors: true,
+  },
+};
 
 export default config;


### PR DESCRIPTION
This pull request introduces a new continuous integration (CI) workflow configuration using GitHub Actions. The workflow is designed to run on every push and includes steps for checking out the repository, installing dependencies, copying environment variable example files, type-checking the code, and linting.

Key changes:

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR1-R23): Added a new CI workflow configuration that runs on every push. The workflow includes steps for checking out the repository, installing dependencies using `pnpm`, copying `.env.example` files, type-checking the code, and linting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `.env.example` file to guide users in setting up their environment variables.
	- Added an automated integration process that streamlines dependency management and code quality checks.

- **Chores**
	- Adjusted build configurations to allow deployments to proceed without interruptions from linting or type-checking errors, ensuring smoother releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->